### PR TITLE
CallerID should be callerId

### DIFF
--- a/xml/plivoxml.go
+++ b/xml/plivoxml.go
@@ -182,7 +182,7 @@ type DialElement struct {
 
 	Timeout *int `xml:"timeout,attr"`
 
-	CallerID *string `xml:"callerID,attr"`
+	CallerID *string `xml:"callerId,attr"`
 
 	CallerName *string `xml:"callerName,attr"`
 


### PR DESCRIPTION
The documentation shows that this should initiate a call with a custom caller ID:

```
<Response>
    <Dial callerId="1111111111">
        <Number>2222222222</Number>
    </Dial>
</Response>
```

https://www.plivo.com/docs/getting-started/dynamic-caller-id/

When looking at the logs, the current golang implementation uses callerID as the keyword as opposed to callerId: this is the only difference I can see and results in:

```
Content : <Response><Speak>Connecting your call..</Speak><Dial callerID="02081236999"><Number>447702102540</Number></Dial></Response>
```

```
Message : Dial callerId '+447702847831' set
```

i.e. the caller id is not set when using `plivo-go`