### PR TITLE
Add missing fields from number

### DIFF
--- a/numbers.go
+++ b/numbers.go
@@ -19,6 +19,13 @@ type Number struct {
 	ResourceURI       string `json:"resource_uri,omitempty" url:"resource_uri,omitempty"`
 	VoiceRate         string `json:"voice_rate,omitempty" url:"voice_rate,omitempty"`
 	SMSRate           string `json:"sms_rate,omitempty" url:"sms_rate,omitempty"`
+	Active            bool   `json:"active,omitempty" url:"active,omitempty"`
+	ApiID             string `json:"api_id,omitempty" url:"api_id,omitempty"`
+	City              string `json:"city,omitempty" url:"city,omitempty"`
+	Country           string `json:"country,omitempty" url:"country,omitempty"`
+	Region            string `json:"region,omitempty" url:"region,omitempty"`
+	Subaccount        string `json:"sub_account,omitempty" url:"sub_account,omitempty"`
+	Type              string `json:"type,omitempty" url:"type,omitempty"`
 }
 
 type NumberCreateParams struct {


### PR DESCRIPTION
Here is the latest response from the API (`https://api.plivo.com/v1/Account/{auth_id}/Number/18042205674/`)
```
{
  "active": true,
  "added_on": "2018-07-16",
  "alias": null,
  "api_id": "3e4ec062-ea8a-11e8-96d8-066208d1cfdc",
  "application": "/v1/Account/MAXXXXXXXXXXXXXXXXXX/Application/12389232799642332/",
  "carrier": "Plivo",
  "city": null,
  "country": "United States",
  "monthly_rental_rate": "0.80000",
  "number": "18042205674",
  "number_type": "local",
  "region": "Virginia, UNITED STATES",
  "resource_uri": "/v1/Account/MAXXXXXXXXXXXXXXXXXX/Number/18042205674/",
  "sms_enabled": true,
  "sms_rate": "0.00000",
  "sub_account": null,
  "type": "fixed",
  "verification_info": [],
  "voice_enabled": true,
  "voice_rate": "0.00850"
}
```