### PR TITLE
[SDKS-123] Response is blank when node_id or phlo_id is incorrect

### DIFF
--- a/baseclient.go
+++ b/baseclient.go
@@ -102,7 +102,11 @@ func (client *BaseClient) ExecuteRequest(request *http.Request, body interface{}
 				err = json.Unmarshal(data, body)
 			}
 		} else {
-			err = errors.New(string(data))
+			if (string(data) == "{}" && response.StatusCode == 404){
+				err = errors.New(string("Resource not found exception \n" + response.Status))
+			}else{
+				err = errors.New(string(data))
+			}
 		}
 	}
 


### PR DESCRIPTION
- Response body is empty from phlorunner.plivo.com when we pass invalid nodeId or phloId.
- Made changes to pass valid error response when we encounter resource not found exception