### PR TITLE
Fix json/url tags

### DIFF
--- a/numbers.go
+++ b/numbers.go
@@ -46,8 +46,8 @@ type NumberListParams struct {
 	Services         string `json:"services,omitempty" url:"services,omitempty"`
 	Alias            string `json:"alias,omitempty" url:"alias,omitempty"`
 
-	Limit  int64 `json:"limit:omitempty" url:"limit:omitempty"`
-	Offset int64 `json:"offset:omitempty" url:"offset:omitempty"`
+	Limit  int64 `json:"limit,omitempty" url:"limit,omitempty"`
+	Offset int64 `json:"offset,omitempty" url:"offset,omitempty"`
 }
 
 type NumberListResponse struct {

--- a/recordings.go
+++ b/recordings.go
@@ -31,8 +31,8 @@ type RecordingListParams struct {
 	AddTimeLessOrEqual string `json:"add_time__lte,omitempty" url:"add_time__lte,omitempty"`
 
 	AddTimeGreaterOrEqual string `json:"add_time__gte,omitempty" url:"add_time__gte,omitempty"`
-	Limit                 int64  `json:"limit:omitempty" url:"limit:omitempty"`
-	Offset                int64  `json:"offset:omitempty" url:"offset:omitempty"`
+	Limit                 int64  `json:"limit,omitempty" url:"limit,omitempty"`
+	Offset                int64  `json:"offset,omitempty" url:"offset,omitempty"`
 }
 
 type RecordingListResponse struct {


### PR DESCRIPTION
Currently, the paging functionality of the Numbers.List() endpoint is broken because URL parameters aren't generated correctly.