### PR TITLE
Revert CallCreateResponse.RequestUUID data type change

### DIFF
--- a/calls.go
+++ b/calls.go
@@ -90,9 +90,9 @@ type CallCreateParams struct {
 
 // Stores response for making a call.
 type CallCreateResponse struct {
-	Message     string      `json:"message" url:"message"`
-	ApiID       string      `json:"api_id" url:"api_id"`
-	RequestUUID interface{} `json:"request_uuid" url:"request_uuid"`
+	Message     string `json:"message" url:"message"`
+	ApiID       string `json:"api_id" url:"api_id"`
+	RequestUUID string `json:"request_uuid" url:"request_uuid"`
 }
 
 type CallListParams struct {


### PR DESCRIPTION
It seems like this has been changed from "string" to "interface{}" in this PR: https://github.com/plivo/plivo-go/pull/77/files#diff-ad3ebf6fd77d67a722e314a5c522bbf92c0be506e5eb23fadfd2358de63c08b9R95

Can someone clarify where in the Plivo docs do they mention `RequestUUID` is not always a string?. Or, in other words, why it was changed to "interface{}" from a string when it is always a string?. 

Docs: https://www.plivo.com/docs/voice/api/call#make-a-call

CC: @varshit97plivo 