### PR TITLE
Remove dependency on logrus

### DIFF
--- a/testutils_test.go
+++ b/testutils_test.go
@@ -3,13 +3,13 @@ package plivo
 import (
 	"fmt"
 	"io/ioutil"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"testing"
 	"unicode"
 
-	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,7 +28,7 @@ var server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *
 	w.WriteHeader(expectedStatusCode)
 	w.Write([]byte(expectedResponse))
 
-	log.Infoln(expectedResponse)
+	log.Println(expectedResponse)
 }))
 
 func expectResponse(fixturePath string, statusCode int) {
@@ -41,7 +41,7 @@ func expectResponse(fixturePath string, statusCode int) {
 		if err != nil {
 			panic(err)
 		}
-		log.Infof("Loaded fixture from %s (%d)\n", fullFixturePath, len(contents))
+		log.Printf("Loaded fixture from %s (%d)\n", fullFixturePath, len(contents))
 		expectedResponse = string(contents)
 	} else {
 		expectedResponse = ""

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,6 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"net/url"
 	"reflect"
 	"sort"
@@ -62,7 +61,6 @@ func Headers(headers map[string]string) string {
 
 func ComputeSignature(authToken, uri string, params map[string]string) string {
 	originalString := fmt.Sprintf("%s%s", uri, headersWithSep(params, "", "", false))
-	logrus.Infof("originalString: %s\n", originalString)
 	mac := hmac.New(sha1.New, []byte(authToken))
 	mac.Write([]byte(originalString))
 	return base64.StdEncoding.EncodeToString(mac.Sum(nil))
@@ -161,7 +159,6 @@ func ComputeSignatureV3(authToken, uri, method string, nonce string, params map[
 	mac := hmac.New(sha256.New, []byte(authToken))
 	mac.Write([]byte(newUrl))
 	var messageMAC = base64.StdEncoding.EncodeToString(mac.Sum(nil))
-	logrus.Info(messageMAC)
 	return messageMAC
 }
 

--- a/xml/plivoxml.go
+++ b/xml/plivoxml.go
@@ -3,12 +3,12 @@ package xml
 import (
 	"encoding/xml"
 	"errors"
-	"github.com/sirupsen/logrus"
+	"strings"
+	"unicode"
+
 	"golang.org/x/text/runes"
 	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
-	"strings"
-	"unicode"
 )
 
 type ResponseElement struct {
@@ -19,8 +19,9 @@ type ResponseElement struct {
 func (element ResponseElement) String() string {
 	bytes, err := xml.Marshal(element)
 	if err != nil {
-		logrus.Errorln(err.Error())
+		return err.Error()
 	}
+
 	return strings.ReplaceAll(strings.ReplaceAll(string(bytes), "<Contents>", ""), "</Contents>", "")
 }
 


### PR DESCRIPTION
Also, removed logging from ComputeSignature() and ComputeSignatureV3().
The SDK shouldn't be logging anything to stdout without user's consent.
