### PR TITLE
Call response.Body.Close() to avoid resource leak

### DIFF
--- a/baseclient.go
+++ b/baseclient.go
@@ -129,6 +129,8 @@ func (client *BaseClient) ExecuteRequest(request *http.Request, body interface{}
 		return
 	}
 
+	defer response.Body.Close()
+
 	data, err := ioutil.ReadAll(response.Body)
 	if err == nil && data != nil && len(data) > 0 {
 		if isVoiceRequest && response.StatusCode >= 500 {


### PR DESCRIPTION
We're seeing a memory leak in this function after repeated requests. Please see https://stackoverflow.com/a/33238755 as to why the response body must be closed to avoid resource leaks.