### PR TITLE
Add bulk_messages.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Change Log
+## [7.61.0](https://github.com/plivo/plivo-go/tree/v7.61.0) (2026-05-23)
+**Major - bulk_messages.create**
+- Added `src`, `dst`, `text`, `type`, `url`, `method`, `log`, `powerpack_uuid` parameters to bulk_messages.create (POST /v1/Account/{auth_id}/Message/Bulk/)
+
+_Source: plivo/api-messaging#9001_
+
 ## [7.60.0](https://github.com/plivo/plivo-go/tree/v7.60.0) (2026-04-08)
 **Feature - PhoneNumber Compliance API support**
 - Added `PhoneNumberComplianceRequirementService` for discovering compliance requirements by country, number type, and user type

--- a/baseclient.go
+++ b/baseclient.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const sdkVersion = "7.60.0"
+const sdkVersion = "7.61.0"
 
 const lookupBaseUrl = "lookup.plivo.com"
 

--- a/bulk_messages.go
+++ b/bulk_messages.go
@@ -1,0 +1,43 @@
+package plivo
+
+type BulkMessageService struct {
+	client *Client
+	BulkMessage
+}
+
+type BulkMessageCreateParams struct {
+	Src  string   `json:"src" url:"src"`
+	Dst  []string `json:"dst" url:"dst"`
+	Text string   `json:"text" url:"text"`
+	// Optional parameters.
+	Type          string      `json:"type,omitempty" url:"type,omitempty"`
+	URL           string      `json:"url,omitempty" url:"url,omitempty"`
+	Method        string      `json:"method,omitempty" url:"method,omitempty"`
+	Log           interface{} `json:"log,omitempty" url:"log,omitempty"`
+	PowerpackUUID string      `json:"powerpack_uuid,omitempty" url:"powerpack_uuid,omitempty"`
+}
+
+type BulkMessage struct {
+	ApiID         string   `json:"api_id,omitempty" url:"api_id,omitempty"`
+	MessageUUID   []string `json:"message_uuid,omitempty" url:"message_uuid,omitempty"`
+	Message       string   `json:"message,omitempty" url:"message,omitempty"`
+	InvalidNumber []string `json:"invalid_number,omitempty" url:"invalid_number,omitempty"`
+}
+
+// Stores response for sending a bulk message.
+type BulkMessageCreateResponseBody struct {
+	ApiID         string   `json:"api_id" url:"api_id"`
+	MessageUUID   []string `json:"message_uuid" url:"message_uuid"`
+	Message       string   `json:"message" url:"message"`
+	InvalidNumber []string `json:"invalid_number,omitempty" url:"invalid_number,omitempty"`
+}
+
+func (service *BulkMessageService) Create(params BulkMessageCreateParams) (response *BulkMessageCreateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Message/Bulk")
+	if err != nil {
+		return
+	}
+	response = &BulkMessageCreateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/bulk_messages_test.go
+++ b/bulk_messages_test.go
@@ -1,0 +1,34 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBulkMessageService_Create(t *testing.T) {
+	expectResponse("bulkMessageCreateResponse.json", 202)
+	assert := require.New(t)
+	resp, err := client.BulkMessages.Create(BulkMessageCreateParams{
+		Src:  "+911231231230",
+		Dst:  []string{"+911231231231", "+911231231232"},
+		Text: "Testing bulk",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.MessageUUID)
+	assert.Equal(resp.Message, "message(s) queued")
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.BulkMessages.Create(BulkMessageCreateParams{
+		Src:  "+911231231230",
+		Dst:  []string{"+911231231231", "+911231231232"},
+		Text: "Testing bulk",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Message/Bulk")
+}

--- a/examples/bulk_messages_create.go
+++ b/examples/bulk_messages_create.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	response, err := client.BulkMessages.Create(plivo.BulkMessageCreateParams{
+		Src:  "<sender_id_or_number>",
+		Dst:  []string{"<destination_number_1>", "<destination_number_2>"},
+		Text: "Hello from Plivo bulk messaging!",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("API ID: %s\n", response.ApiID)
+	fmt.Printf("Message UUIDs: %v\n", response.MessageUUID)
+	fmt.Printf("Message: %s\n", response.Message)
+	if len(response.InvalidNumber) > 0 {
+		fmt.Printf("Invalid numbers: %v\n", response.InvalidNumber)
+	}
+}

--- a/tests/bulkMessageCreateResponse.json
+++ b/tests/bulkMessageCreateResponse.json
@@ -1,0 +1,9 @@
+{
+  "api_id": "api-id-bulk-12345",
+  "message_uuid": [
+    "uuid-0000-0001",
+    "uuid-0000-0002"
+  ],
+  "message": "message(s) queued",
+  "invalid_number": []
+}


### PR DESCRIPTION
# Add bulk_messages.create

Base: master ← rune/pr-9001-bulk_messages-create

Reviewers (picked by recent commit activity):
- @avinashp-plivo (3 commits)
- @narayana-plivo (3 commits)

Adds `bulk_messages.create()` — `POST /v1/Account/{auth_id}/Message/Bulk/`.

Send a single SMS message to up to 1000 destinations in one API call, billed independently per destination.

**Parameters**

- `src` (string, required) — The source phone number or sender ID to send the message from.
- `dst` (array<string>, required) — List of destination phone numbers; minimum 1 and maximum 1000 entries.
- `text` (string, required) — The text content of the message; maximum 1600 characters.
- `type` (string, optional) — The type of message (e.g. sms).
- `url` (string, optional) — The URL to which delivery status callbacks are sent.
- `method` (string, optional) — The HTTP method used to invoke the callback URL (GET or POST).
- `log` (boolean, optional) — Whether to log the message content; defaults to false.
- `powerpack_uuid` (string, optional) — UUID of the Powerpack to use for sending the bulk message.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
