### PR TITLE
Add whatsapp_templates.create, whatsapp_templates.update, verify_apps.create, verify_apps.list, verify_app_templates.list, verify_apps.get, verify_apps.update, verify_apps.delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,17 @@
 # Change Log
+## [7.61.0](https://github.com/plivo/plivo-go/tree/v7.61.0) (2026-05-23)
+**Feature - whatsapp_templates, verify_apps, verify_app_templates API updates**
+- Added `application_id` optional parameter to whatsapp_templates.create (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `application_id` optional parameter to whatsapp_templates.update (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `brand_name`, `sms_channel`, `voice_channel`, `wa_channel`, `is_default`, `template_uuid`, `message_redaction`, `customer_app_hash`, `max_validation_attempts`, `enable_fraudshield`, `fs_protection_level`, `waba_id`, `waba_phone_number`, `waba_template_id` parameters to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+- Added `name`, `app_uuid`, `channel`, `status`, `limit`, `offset`, `created_at`, `created_at__lt`, `created_at__lte`, `created_at__gt`, `created_at__gte`, `subaccount_auth_id` parameters to verify_apps.list (GET /v1/Account/{auth_id}/Verify/App/)
+- GET /v1/Account/{auth_id}/Verify/App/templates/ — verify_app_templates.list. List available SMS OTP templates for the account including account-owned and Plivo system defaults.
+- GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/ — verify_apps.get. Retrieve details of a specific Verify App by its UUID.
+- Added `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `is_default`, `template_uuid`, `message_redaction`, `customer_app_hash`, `max_validation_attempts`, `enable_fraudshield`, `fs_protection_level`, `waba_id`, `waba_phone_number`, `waba_template_id` parameters to verify_apps.update (POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/ — verify_apps.delete. Soft-delete a Verify App by its UUID.
+
+_Source: plivo/api-messaging#629_
+
 ## [7.60.0](https://github.com/plivo/plivo-go/tree/v7.60.0) (2026-04-08)
 **Feature - PhoneNumber Compliance API support**
 - Added `PhoneNumberComplianceRequirementService` for discovering compliance requirements by country, number type, and user type

--- a/baseclient.go
+++ b/baseclient.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const sdkVersion = "7.60.0"
+const sdkVersion = "7.61.0"
 
 const lookupBaseUrl = "lookup.plivo.com"
 

--- a/examples/verify_app_templates_list.go
+++ b/examples/verify_app_templates_list.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := client.VerifyAppTemplates.List()
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("API ID: %s\n", resp.ApiID)
+	for _, tmpl := range resp.Templates {
+		fmt.Printf("Template UUID: %s, Friendly Name: %s, Locale: %s\n",
+			tmpl.TemplateUUID, tmpl.FriendlyName, tmpl.Locale)
+	}
+}

--- a/examples/verify_apps_create.go
+++ b/examples/verify_apps_create.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := client.VerifyApps.Create(plivo.VerifyAppCreateParams{
+		Name:      "My Verify App",
+		OtpLength: 6,
+		OtpExpiry: 5,
+		BrandName: "My Brand",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("App UUID: %s\n", resp.AppUUID)
+	fmt.Printf("Message: %s\n", resp.Message)
+}

--- a/examples/verify_apps_delete.go
+++ b/examples/verify_apps_delete.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	appUUID := "your-app-uuid-here"
+	resp, err := client.VerifyApps.Delete(appUUID)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("App UUID: %s\n", resp.AppUUID)
+	fmt.Printf("Message: %s\n", resp.Message)
+}

--- a/examples/verify_apps_get.go
+++ b/examples/verify_apps_get.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	appUUID := "your-app-uuid-here"
+	resp, err := client.VerifyApps.Get(appUUID)
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("App UUID: %s\n", resp.VerifyApp.AppUUID)
+	fmt.Printf("Name: %s\n", resp.VerifyApp.Name)
+}

--- a/examples/verify_apps_list.go
+++ b/examples/verify_apps_list.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	resp, err := client.VerifyApps.List(plivo.VerifyAppListParams{
+		Limit:  20,
+		Offset: 0,
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("Total apps: %d\n", resp.Meta.TotalCount)
+	for _, app := range resp.VerifyApps {
+		fmt.Printf("App UUID: %s, Name: %s\n", app.AppUUID, app.Name)
+	}
+}

--- a/examples/verify_apps_update.go
+++ b/examples/verify_apps_update.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"fmt"
+
+	plivo "github.com/plivo/plivo-go"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		panic(err)
+	}
+
+	appUUID := "your-app-uuid-here"
+	resp, err := client.VerifyApps.Update(appUUID, plivo.VerifyAppUpdateParams{
+		Name:      "Updated App Name",
+		BrandName: "Updated Brand",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("App UUID: %s\n", resp.AppUUID)
+	fmt.Printf("Message: %s\n", resp.Message)
+}

--- a/fixtures/verifyAppTemplateListResponse.json
+++ b/fixtures/verifyAppTemplateListResponse.json
@@ -1,0 +1,17 @@
+{
+  "api_id": "api-id-abcd-1234",
+  "templates": [
+    {
+      "template_uuid": "tmpl-uuid-0001",
+      "text": "Your OTP is {{otp}}. Valid for 10 minutes.",
+      "friendly_name": "Default OTP Template",
+      "locale": "en"
+    },
+    {
+      "template_uuid": "tmpl-uuid-0002",
+      "text": "{{otp}} is your verification code.",
+      "friendly_name": "Short OTP Template",
+      "locale": "en"
+    }
+  ]
+}

--- a/pkg/whatsappclient/template.go
+++ b/pkg/whatsappclient/template.go
@@ -1,0 +1,128 @@
+package whatsappclient
+
+import "github.com/plivo/plivo-go"
+
+type WhatsAppTemplateService struct {
+	client *plivo.Client
+}
+
+type WhatsAppTemplateComponent struct {
+	Type       string                          `json:"type,omitempty"`
+	Format     string                          `json:"format,omitempty"`
+	Text       string                          `json:"text,omitempty"`
+	Buttons    []WhatsAppTemplateButton        `json:"buttons,omitempty"`
+	Cards      []WhatsAppTemplateCard          `json:"cards,omitempty"`
+	Parameters []WhatsAppTemplateParameter     `json:"parameters,omitempty"`
+	Example    *WhatsAppTemplateComponentExample `json:"example,omitempty"`
+}
+
+type WhatsAppTemplateButton struct {
+	Type        string `json:"type,omitempty"`
+	Text        string `json:"text,omitempty"`
+	URL         string `json:"url,omitempty"`
+	PhoneNumber string `json:"phone_number,omitempty"`
+	OTPType     string `json:"otp_type,omitempty"`
+	AutofillText string `json:"autofill_text,omitempty"`
+	PackageName  string `json:"package_name,omitempty"`
+	SignatureHash string `json:"signature_hash,omitempty"`
+}
+
+type WhatsAppTemplateCard struct {
+	Components []WhatsAppTemplateComponent `json:"components,omitempty"`
+}
+
+type WhatsAppTemplateParameter struct {
+	Type string `json:"type,omitempty"`
+	Text string `json:"text,omitempty"`
+}
+
+type WhatsAppTemplateComponentExample struct {
+	HeaderText   []string   `json:"header_text,omitempty"`
+	BodyText     [][]string `json:"body_text,omitempty"`
+	HeaderHandle []string   `json:"header_handle,omitempty"`
+}
+
+type WhatsAppTemplateCreateParams struct {
+	ElementName    string                      `json:"elementName,omitempty"`
+	LanguageCode   string                      `json:"languageCode,omitempty"`
+	LanguagePolicy string                      `json:"languagePolicy,omitempty"`
+	Category       string                      `json:"category,omitempty"`
+	Components     []WhatsAppTemplateComponent `json:"components,omitempty"`
+	// Optional parameters.
+	ApplicationID string `json:"application_id,omitempty"`
+}
+
+type WhatsAppTemplateUpdateParams struct {
+	Category   string                      `json:"category,omitempty"`
+	Components []WhatsAppTemplateComponent `json:"components,omitempty"`
+	// Optional parameters.
+	ApplicationID string `json:"application_id,omitempty"`
+}
+
+type WhatsAppTemplateResponse struct {
+	ApiID   string `json:"api_id,omitempty"`
+	Message string `json:"message,omitempty"`
+}
+
+type WhatsAppTemplate struct {
+	ID           string                      `json:"id,omitempty"`
+	ElementName  string                      `json:"elementName,omitempty"`
+	LanguageCode string                      `json:"languageCode,omitempty"`
+	Category     string                      `json:"category,omitempty"`
+	Status       string                      `json:"status,omitempty"`
+	Components   []WhatsAppTemplateComponent `json:"components,omitempty"`
+}
+
+type WhatsAppTemplateListResponse struct {
+	ApiID    string             `json:"api_id,omitempty"`
+	Response []WhatsAppTemplate `json:"response,omitempty"`
+}
+
+func (service *WhatsAppTemplateService) Create(wabaID string, params WhatsAppTemplateCreateParams) (response *WhatsAppTemplateResponse, err error) {
+	req, err := service.client.NewRequest("POST", params, "WhatsApp/Template/%s/", wabaID)
+	if err != nil {
+		return
+	}
+	response = &WhatsAppTemplateResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsAppTemplateService) Update(wabaID string, templateID string, params WhatsAppTemplateUpdateParams) (response *WhatsAppTemplateResponse, err error) {
+	req, err := service.client.NewRequest("POST", params, "WhatsApp/Template/%s/%s/", wabaID, templateID)
+	if err != nil {
+		return
+	}
+	response = &WhatsAppTemplateResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsAppTemplateService) Get(wabaID string, templateName string) (response *WhatsAppTemplateListResponse, err error) {
+	req, err := service.client.NewRequest("GET", nil, "WhatsApp/Template/%s/%s/", wabaID, templateName)
+	if err != nil {
+		return
+	}
+	response = &WhatsAppTemplateListResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsAppTemplateService) List(wabaID string) (response *WhatsAppTemplateListResponse, err error) {
+	req, err := service.client.NewRequest("GET", nil, "WhatsApp/Template/%s/", wabaID)
+	if err != nil {
+		return
+	}
+	response = &WhatsAppTemplateListResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsAppTemplateService) Delete(wabaID string, templateID string) (err error) {
+	req, err := service.client.NewRequest("DELETE", nil, "WhatsApp/Template/%s/%s/", wabaID, templateID)
+	if err != nil {
+		return
+	}
+	err = service.client.ExecuteRequest(req, nil)
+	return
+}

--- a/pkg/whatsappclient/template_test.go
+++ b/pkg/whatsappclient/template_test.go
@@ -1,0 +1,45 @@
+package whatsappclient
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWhatsAppTemplateCreateParams_ApplicationID(t *testing.T) {
+	params := WhatsAppTemplateCreateParams{
+		ElementName:  "test_template",
+		LanguageCode: "en_US",
+		Category:     "UTILITY",
+		ApplicationID: "test-app-id",
+	}
+	assert.Equal(t, "test-app-id", params.ApplicationID)
+	assert.Equal(t, "test_template", params.ElementName)
+	assert.Equal(t, "en_US", params.LanguageCode)
+	assert.Equal(t, "UTILITY", params.Category)
+}
+
+func TestWhatsAppTemplateCreateParams_ApplicationID_Optional(t *testing.T) {
+	params := WhatsAppTemplateCreateParams{
+		ElementName:  "test_template",
+		LanguageCode: "en_US",
+		Category:     "UTILITY",
+	}
+	assert.Equal(t, "", params.ApplicationID)
+}
+
+func TestWhatsAppTemplateUpdateParams_ApplicationID(t *testing.T) {
+	params := WhatsAppTemplateUpdateParams{
+		Category:      "MARKETING",
+		ApplicationID: "updated-app-id",
+	}
+	assert.Equal(t, "updated-app-id", params.ApplicationID)
+	assert.Equal(t, "MARKETING", params.Category)
+}
+
+func TestWhatsAppTemplateUpdateParams_ApplicationID_Optional(t *testing.T) {
+	params := WhatsAppTemplateUpdateParams{
+		Category: "MARKETING",
+	}
+	assert.Equal(t, "", params.ApplicationID)
+}

--- a/verify_app_templates.go
+++ b/verify_app_templates.go
@@ -1,0 +1,27 @@
+package plivo
+
+type VerifyAppTemplateService struct {
+	client *Client
+}
+
+type VerifyTemplate struct {
+	TemplateUUID string `json:"template_uuid,omitempty"`
+	Text         string `json:"text,omitempty"`
+	FriendlyName string `json:"friendly_name,omitempty"`
+	Locale       string `json:"locale,omitempty"`
+}
+
+type VerifyAppTemplateListResponse struct {
+	ApiID     string           `json:"api_id"`
+	Templates []VerifyTemplate `json:"templates"`
+}
+
+func (service *VerifyAppTemplateService) List() (response *VerifyAppTemplateListResponse, err error) {
+	req, err := service.client.NewRequest("GET", nil, "Verify/App/templates/")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppTemplateListResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/verify_app_templates_test.go
+++ b/verify_app_templates_test.go
@@ -1,0 +1,26 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVerifyAppTemplateService_List(t *testing.T) {
+	expectResponse("verifyAppTemplateListResponse.json", 200)
+	assert := assert.New(t)
+	resp, err := client.VerifyAppTemplates.List()
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotNil(resp.Templates)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyAppTemplates.List()
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App/templates/")
+}

--- a/verify_apps.go
+++ b/verify_apps.go
@@ -1,0 +1,185 @@
+package plivo
+
+type VerifyAppService struct {
+	client *Client
+	VerifyApp
+}
+
+type VerifyAppCreateParams struct {
+	Name                  string `json:"name" url:"name"`
+	OtpType               string `json:"otp_type,omitempty" url:"otp_type,omitempty"`
+	OtpLength             int    `json:"otp_length,omitempty" url:"otp_length,omitempty"`
+	OtpExpiry             int    `json:"otp_expiry,omitempty" url:"otp_expiry,omitempty"`
+	OtpAttempts           int    `json:"otp_attempts,omitempty" url:"otp_attempts,omitempty"`
+	BrandName             string `json:"brand_name,omitempty" url:"brand_name,omitempty"`
+	SmsChannel            *bool  `json:"sms_channel,omitempty" url:"sms_channel,omitempty"`
+	VoiceChannel          *bool  `json:"voice_channel,omitempty" url:"voice_channel,omitempty"`
+	WaChannel             *bool  `json:"wa_channel,omitempty" url:"wa_channel,omitempty"`
+	IsDefault             *bool  `json:"is_default,omitempty" url:"is_default,omitempty"`
+	TemplateUUID          string `json:"template_uuid,omitempty" url:"template_uuid,omitempty"`
+	MessageRedaction      *bool  `json:"message_redaction,omitempty" url:"message_redaction,omitempty"`
+	CustomerAppHash       string `json:"customer_app_hash,omitempty" url:"customer_app_hash,omitempty"`
+	MaxValidationAttempts int    `json:"max_validation_attempts,omitempty" url:"max_validation_attempts,omitempty"`
+	EnableFraudshield     *bool  `json:"enable_fraudshield,omitempty" url:"enable_fraudshield,omitempty"`
+	FsProtectionLevel     string `json:"fs_protection_level,omitempty" url:"fs_protection_level,omitempty"`
+	WabaID                string `json:"waba_id,omitempty" url:"waba_id,omitempty"`
+	WabaPhoneNumber       string `json:"waba_phone_number,omitempty" url:"waba_phone_number,omitempty"`
+	WabaTemplateID        string `json:"waba_template_id,omitempty" url:"waba_template_id,omitempty"`
+}
+
+type VerifyAppUpdateParams struct {
+	Name                  string `json:"name,omitempty" url:"name,omitempty"`
+	BrandName             string `json:"brand_name,omitempty" url:"brand_name,omitempty"`
+	OtpType               string `json:"otp_type,omitempty" url:"otp_type,omitempty"`
+	OtpLength             int    `json:"otp_length,omitempty" url:"otp_length,omitempty"`
+	OtpExpiry             int    `json:"otp_expiry,omitempty" url:"otp_expiry,omitempty"`
+	OtpAttempts           int    `json:"otp_attempts,omitempty" url:"otp_attempts,omitempty"`
+	SmsChannel            *bool  `json:"sms_channel,omitempty" url:"sms_channel,omitempty"`
+	VoiceChannel          *bool  `json:"voice_channel,omitempty" url:"voice_channel,omitempty"`
+	WaChannel             *bool  `json:"wa_channel,omitempty" url:"wa_channel,omitempty"`
+	IsDefault             *bool  `json:"is_default,omitempty" url:"is_default,omitempty"`
+	TemplateUUID          string `json:"template_uuid,omitempty" url:"template_uuid,omitempty"`
+	MessageRedaction      *bool  `json:"message_redaction,omitempty" url:"message_redaction,omitempty"`
+	CustomerAppHash       string `json:"customer_app_hash,omitempty" url:"customer_app_hash,omitempty"`
+	MaxValidationAttempts int    `json:"max_validation_attempts,omitempty" url:"max_validation_attempts,omitempty"`
+	EnableFraudshield     *bool  `json:"enable_fraudshield,omitempty" url:"enable_fraudshield,omitempty"`
+	FsProtectionLevel     string `json:"fs_protection_level,omitempty" url:"fs_protection_level,omitempty"`
+	WabaID                string `json:"waba_id,omitempty" url:"waba_id,omitempty"`
+	WabaPhoneNumber       string `json:"waba_phone_number,omitempty" url:"waba_phone_number,omitempty"`
+	WabaTemplateID        string `json:"waba_template_id,omitempty" url:"waba_template_id,omitempty"`
+}
+
+type VerifyAppListParams struct {
+	Name               string `url:"name,omitempty"`
+	AppUUID            string `url:"app_uuid,omitempty"`
+	Channel            string `url:"channel,omitempty"`
+	Status             string `url:"status,omitempty"`
+	Limit              int    `url:"limit,omitempty"`
+	Offset             int    `url:"offset,omitempty"`
+	CreatedAt          string `url:"created_at,omitempty"`
+	CreatedAtLt        string `url:"created_at__lt,omitempty"`
+	CreatedAtLte       string `url:"created_at__lte,omitempty"`
+	CreatedAtGt        string `url:"created_at__gt,omitempty"`
+	CreatedAtGte       string `url:"created_at__gte,omitempty"`
+	SubaccountAuthID   string `url:"subaccount_auth_id,omitempty"`
+}
+
+type VerifyApp struct {
+	AppUUID               string `json:"app_uuid,omitempty"`
+	Name                  string `json:"name,omitempty"`
+	OtpType               string `json:"otp_type,omitempty"`
+	OtpLength             int    `json:"otp_length,omitempty"`
+	OtpExpiry             int    `json:"otp_expiry,omitempty"`
+	OtpAttempts           int    `json:"otp_attempts,omitempty"`
+	BrandName             string `json:"brand_name,omitempty"`
+	SmsChannel            *bool  `json:"sms_channel,omitempty"`
+	VoiceChannel          *bool  `json:"voice_channel,omitempty"`
+	WaChannel             *bool  `json:"wa_channel,omitempty"`
+	IsDefault             *bool  `json:"is_default,omitempty"`
+	TemplateUUID          string `json:"template_uuid,omitempty"`
+	MessageRedaction      *bool  `json:"message_redaction,omitempty"`
+	CustomerAppHash       string `json:"customer_app_hash,omitempty"`
+	MaxValidationAttempts int    `json:"max_validation_attempts,omitempty"`
+	EnableFraudshield     *bool  `json:"enable_fraudshield,omitempty"`
+	FsProtectionLevel     string `json:"fs_protection_level,omitempty"`
+	WabaID                string `json:"waba_id,omitempty"`
+	WabaPhoneNumber       string `json:"waba_phone_number,omitempty"`
+	WabaTemplateID        string `json:"waba_template_id,omitempty"`
+}
+
+type VerifyWhatsapp struct {
+	WabaID          string `json:"waba_id,omitempty"`
+	WabaPhoneNumber string `json:"waba_phone_number,omitempty"`
+	WabaTemplateID  string `json:"waba_template_id,omitempty"`
+}
+
+type VerifyAppCreateResponseBody struct {
+	ApiID   string `json:"api_id,omitempty"`
+	AppUUID string `json:"app_uuid,omitempty"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type VerifyAppUpdateResponseBody struct {
+	ApiID   string `json:"api_id,omitempty"`
+	AppUUID string `json:"app_uuid,omitempty"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type VerifyAppDeleteResponseBody struct {
+	ApiID   string `json:"api_id,omitempty"`
+	AppUUID string `json:"app_uuid,omitempty"`
+	Message string `json:"message,omitempty"`
+	Error   string `json:"error,omitempty"`
+}
+
+type VerifyAppGetResponseBody struct {
+	ApiID          string          `json:"api_id,omitempty"`
+	VerifyApp      *VerifyApp      `json:"verify_app,omitempty"`
+	VerifyWhatsapp *VerifyWhatsapp `json:"verify_whatsapp,omitempty"`
+}
+
+type VerifyAppListMeta struct {
+	Previous   *string `json:"previous,omitempty"`
+	Next       *string `json:"next,omitempty"`
+	Limit      int64   `json:"limit,omitempty"`
+	Offset     int64   `json:"offset,omitempty"`
+	TotalCount int64   `json:"total_count,omitempty"`
+}
+
+type VerifyAppList struct {
+	ApiID       string            `json:"api_id,omitempty"`
+	Meta        VerifyAppListMeta `json:"meta"`
+	VerifyApps  []VerifyApp       `json:"verify_apps"`
+}
+
+func (service *VerifyAppService) Create(params VerifyAppCreateParams) (response *VerifyAppCreateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Verify/App")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppCreateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) List(params VerifyAppListParams) (response *VerifyAppList, err error) {
+	req, err := service.client.NewRequest("GET", params, "Verify/App")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppList{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Get(appUUID string) (response *VerifyAppGetResponseBody, err error) {
+	req, err := service.client.NewRequest("GET", nil, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	response = &VerifyAppGetResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Update(appUUID string, params VerifyAppUpdateParams) (response *VerifyAppUpdateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	response = &VerifyAppUpdateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Delete(appUUID string) (response *VerifyAppDeleteResponseBody, err error) {
+	req, err := service.client.NewRequest("DELETE", nil, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	response = &VerifyAppDeleteResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/verify_apps_test.go
+++ b/verify_apps_test.go
@@ -1,0 +1,113 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAppService_Create(t *testing.T) {
+	expectResponse("verifyAppCreateResponse.json", 201)
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Create(VerifyAppCreateParams{
+		Name: "Test App",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.AppUUID)
+	assert.Equal(resp.Error, "")
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Create(VerifyAppCreateParams{
+		Name: "Test App",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Verify/App")
+}
+
+func TestVerifyAppService_List(t *testing.T) {
+	expectResponse("verifyAppListResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.VerifyApps.List(VerifyAppListParams{})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.VerifyApps)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.List(VerifyAppListParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App")
+}
+
+func TestVerifyAppService_Get(t *testing.T) {
+	expectResponse("verifyAppGetResponse.json", 200)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Get(appUUID)
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.VerifyApp)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Get(appUUID)
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App/%s", appUUID)
+}
+
+func TestVerifyAppService_Update(t *testing.T) {
+	expectResponse("verifyAppUpdateResponse.json", 200)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Update(appUUID, VerifyAppUpdateParams{
+		Name: "Updated App",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.AppUUID)
+	assert.Equal(resp.Error, "")
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Update(appUUID, VerifyAppUpdateParams{
+		Name: "Updated App",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Verify/App/%s", appUUID)
+}
+
+func TestVerifyAppService_Delete(t *testing.T) {
+	expectResponse("verifyAppDeleteResponse.json", 200)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Delete(appUUID)
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.Equal(resp.Error, "")
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Delete(appUUID)
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "DELETE", "Verify/App/%s", appUUID)
+}


### PR DESCRIPTION
# Add whatsapp_templates.create, whatsapp_templates.update, verify_apps.create, verify_apps.list, verify_app_templates.list, verify_apps.get, verify_apps.update, verify_apps.delete

Base: master ← rune/pr-629-sdk-updates

Reviewers (picked by recent commit activity):
- @avinashp-plivo (3 commits)
- @narayana-plivo (3 commits)

Adds the following methods:

- `whatsapp_templates.create()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — Add optional application_id field to the WhatsApp template create request.
- `whatsapp_templates.update()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Add optional application_id field to the WhatsApp template update request.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Create a new Verify App for OTP delivery with optional channel and configuration settings.
- `verify_apps.list()` — `GET /v1/Account/{auth_id}/Verify/App/` — List Verify Apps owned by the account with optional filtering and pagination.
- `verify_app_templates.list()` — `GET /v1/Account/{auth_id}/Verify/App/templates/` — List available SMS OTP templates for the account including account-owned and Plivo system defaults.
- `verify_apps.get()` — `GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Retrieve details of a specific Verify App by its UUID.
- `verify_apps.update()` — `POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Partially update a Verify App; only fields included in the request body are modified.
- `verify_apps.delete()` — `DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Soft-delete a Verify App by its UUID.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
