### PR TITLE
Add whatsapp_templates.create, whatsapp_templates.update, whatsapp_templates.get, whatsapp_templates.list, whatsapp_templates.delete, verify_apps.create, verify_apps.list, verify_apps.list_templates, verify_apps.get, verify_apps.update, verify_apps.delete, rcs_capability.check, rcs_assistant_events.create, verify_session.create, messages.create, messages.list, messages.get, verify_apps.create

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,27 @@
 # Change Log
+## [7.61.0](https://github.com/plivo/plivo-go/tree/v7.61.0) (2026-05-23)
+**Feature - whatsapp_templates, verify_apps, rcs_capability, rcs_assistant_events, verify_session, messages API updates**
+- Added `waba_id`, `name`, `category`, `language`, `components`, `allow_category_change` parameters to whatsapp_templates.create (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `waba_id`, `template_id`, `name`, `category`, `language`, `components`, `allow_category_change` parameters to whatsapp_templates.update (POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `waba_id`, `template_id` parameters to whatsapp_templates.get (GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `waba_id`, `template_name`, `limit`, `offset` parameters to whatsapp_templates.list (GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/)
+- Added `waba_id`, `template_id`, `name` parameters to whatsapp_templates.delete (DELETE /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/)
+- Added `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `max_validation_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `waba_id`, `waba_phone_number`, `waba_template_id`, `template_uuid`, `is_default`, `message_redaction`, `enable_fraudshield`, `fs_protection_level`, `customer_app_hash`, `number_pool` parameters to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+- Added `name`, `subaccount`, `limit`, `offset`, `created_at`, `created_at__lt`, `created_at__lte`, `created_at__gt`, `created_at__gte` parameters to verify_apps.list (GET /v1/Account/{auth_id}/Verify/App/)
+- GET /v1/Account/{auth_id}/Verify/App/templates/ — verify_apps.list_templates. List default Verify templates available to the account.
+- Added `app_uuid` required parameter to verify_apps.get (GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `app_uuid`, `name`, `brand_name`, `otp_type`, `otp_length`, `otp_expiry`, `otp_attempts`, `max_validation_attempts`, `sms_channel`, `voice_channel`, `wa_channel`, `waba_id`, `waba_phone_number`, `waba_template_id`, `template_uuid`, `is_default`, `message_redaction`, `enable_fraudshield`, `fs_protection_level`, `customer_app_hash`, `client` parameters to verify_apps.update (POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `app_uuid` required parameter to verify_apps.delete (DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/)
+- Added `phone_number`, `agent_uuid` parameters to rcs_capability.check (GET /v1/Account/{auth_id}/RCS/Capability/)
+- POST /v1/Account/{auth_id}/RCS/AssistantEvents/ — rcs_assistant_events.create. Send RCS assistant events.
+- Added `app_hash`, `brand_name`, `code_length`, `dlt_entity_id`, `dlt_sender_id`, `dlt_template_category`, `dlt_template_id`, `dlt_text`, `dtmf`, `fraud_check`, `text` parameters to verify_session.create (POST /v1/Account/{auth_id}/Verify/Session/)
+- Added `content_message` optional parameter to messages.create (POST /v1/Account/{auth_id}/Message/)
+- GET /v1/Account/{auth_id}/Message/ — messages.list. Add error_message, message_sent_time, and message_updated_time fields to the list messages response.
+- GET /v1/Account/{auth_id}/Message/{record_id}/ — messages.get. Add error_message, message_sent_time, and message_updated_time fields to the get message response.
+- Added `number_pool` optional parameter to verify_apps.create (POST /v1/Account/{auth_id}/Verify/App/)
+
+_Source: plivo/api-messaging#630_
+
 ## [7.60.0](https://github.com/plivo/plivo-go/tree/v7.60.0) (2026-04-08)
 **Feature - PhoneNumber Compliance API support**
 - Added `PhoneNumberComplianceRequirementService` for discovering compliance requirements by country, number type, and user type

--- a/baseclient.go
+++ b/baseclient.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const sdkVersion = "7.60.0"
+const sdkVersion = "7.61.0"
 
 const lookupBaseUrl = "lookup.plivo.com"
 

--- a/client.go
+++ b/client.go
@@ -1,0 +1,139 @@
+package plivo
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+)
+
+const (
+	voiceBaseUrlString          = "voice.plivo.com"
+	voiceBaseUrlStringFallback1 = "voice1.plivo.com"
+	voiceBaseUrlStringFallback2 = "voice2.plivo.com"
+	CallInsightsBaseURL         = "insights.plivo.com"
+	HttpsScheme                 = "https"
+)
+
+type Client struct {
+	httpClient *http.Client
+
+	AuthId    string
+	AuthToken string
+
+	BaseUrl   *url.URL
+	userAgent string
+
+	RequestInterceptor  func(request *http.Request)
+	ResponseInterceptor func(response *http.Response)
+
+	Account      AccountService
+	Subaccounts  SubaccountService
+	Applications ApplicationService
+	Calls        CallService
+	LiveCalls     LiveCallService
+	QueuedCalls   QueuedCallService
+	ConferenceCalls ConferenceService
+	Endpoints    EndpointService
+	Messages     MessageService
+	Lookup       LookupService
+	Powerpacks   PowerpackService
+	Media        MediaService
+	Numbers      NumberService
+	PhoneNumbers PhoneNumberService
+	Pricings     PricingService
+	Recordings   RecordingService
+	Identities   IdentityService
+	Addresses    AddressService
+	Nodes        *NodeService
+	MultiPartyCall MultiPartyCallService
+	RcsCapability RcsCapabilityService
+}
+
+func NewClient(authId string, authToken string, options *Options) (client *Client, err error) {
+	_, authIdIsSet := os.LookupEnv("PLIVO_AUTH_ID")
+	_, authTokenIsSet := os.LookupEnv("PLIVO_AUTH_TOKEN")
+
+	if authId == "" {
+		if authIdIsSet {
+			authId = os.Getenv("PLIVO_AUTH_ID")
+		} else {
+			return nil, fmt.Errorf("authID not provided and PLIVO_AUTH_ID env var is not set")
+		}
+	}
+
+	if authToken == "" {
+		if authTokenIsSet {
+			authToken = os.Getenv("PLIVO_AUTH_TOKEN")
+		} else {
+			return nil, fmt.Errorf("authToken not provided and PLIVO_AUTH_TOKEN env var is not set")
+		}
+	}
+
+	if options == nil {
+		options = &Options{}
+	}
+
+	httpClient := http.DefaultClient
+	if options.HttpClient != nil {
+		httpClient = options.HttpClient
+	}
+
+	baseUrl, err := url.Parse(fmt.Sprintf("https://api.plivo.com/v1/Account/%s/", authId))
+	if err != nil {
+		return
+	}
+
+	userAgent := fmt.Sprintf("plivo-go/%s (Go %s)", sdkVersion, goVersion())
+
+	client = &Client{
+		httpClient: httpClient,
+		AuthId:     authId,
+		AuthToken:  authToken,
+		BaseUrl:    baseUrl,
+		userAgent:  userAgent,
+	}
+
+	client.Account = AccountService{client: client}
+	client.Subaccounts = SubaccountService{client: client}
+	client.Applications = ApplicationService{client: client}
+	client.Calls = CallService{client: client}
+	client.LiveCalls = LiveCallService{client: client}
+	client.QueuedCalls = QueuedCallService{client: client}
+	client.ConferenceCalls = ConferenceService{client: client}
+	client.Endpoints = EndpointService{client: client}
+	client.Messages = MessageService{client: client}
+	client.Lookup = LookupService{client: client}
+	client.Powerpacks = PowerpackService{client: client}
+	client.Media = MediaService{client: client}
+	client.Numbers = NumberService{client: client}
+	client.PhoneNumbers = PhoneNumberService{client: client}
+	client.Pricings = PricingService{client: client}
+	client.Recordings = RecordingService{client: client}
+	client.Identities = IdentityService{client: client}
+	client.Addresses = AddressService{client: client}
+	client.MultiPartyCall = MultiPartyCallService{client: client}
+	client.RcsCapability = RcsCapabilityService{client: client}
+
+	return
+}
+
+func checkAndFetchCallInsightsRequestDetails(param interface{}) (bool, string) {
+	if param == nil {
+		return false, ""
+	}
+	paramStr, ok := param.(string)
+	if !ok {
+		return false, ""
+	}
+	re := regexp.MustCompile(`^[a-f0-9-]{36}$`)
+	if re.MatchString(paramStr) {
+		return false, ""
+	}
+	insightsRe := regexp.MustCompile(`insights`)
+	if insightsRe.MatchString(paramStr) {
+		return true, paramStr
+	}
+	return false, ""
+}

--- a/examples/rcs_capability_check.go
+++ b/examples/rcs_capability_check.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.Options{})
+	if err != nil {
+		panic(err)
+	}
+
+	response, err := client.RcsCapability.Check(plivo.RcsCapabilityParams{
+		PhoneNumber: "+14151234567",
+		AgentUUID:   "your-agent-uuid",
+	})
+	if err != nil {
+		panic(err)
+	}
+
+	fmt.Printf("API ID: %s\n", response.ApiID)
+	fmt.Printf("Phone Number: %s\n", response.PhoneNumber)
+	fmt.Printf("Is Capable: %v\n", response.IsCapable)
+	fmt.Printf("Features: %v\n", response.Features)
+	fmt.Printf("Message: %s\n", response.Message)
+}

--- a/examples/whatsapp_templates_create.go
+++ b/examples/whatsapp_templates_create.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		fmt.Printf("Error initializing client: %s\n", err)
+		return
+	}
+
+	resp, err := client.WhatsappTemplates.Create(
+		"your_waba_id",
+		plivo.WhatsappTemplateCreateParams{
+			Name:                "sample_template",
+			Category:            "MARKETING",
+			Language:            "en_US",
+			AllowCategoryChange: true,
+			Components: []plivo.WhatsappTemplateComponent{
+				{
+					Type: "BODY",
+					Parameters: []plivo.Parameter{
+						{
+							Type: "text",
+							Text: "Hello World",
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error creating WhatsApp template: %s\n", err)
+		return
+	}
+	fmt.Printf("Template created: %+v\n", resp)
+}

--- a/examples/whatsapp_templates_delete.go
+++ b/examples/whatsapp_templates_delete.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		fmt.Printf("Error initializing client: %s\n", err)
+		return
+	}
+
+	err = client.WhatsappTemplates.Delete(
+		"your_waba_id",
+		"your_template_id",
+		plivo.WhatsappTemplateDeleteParams{
+			Name: "sample_template",
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error deleting WhatsApp template: %s\n", err)
+		return
+	}
+	fmt.Println("Template deleted successfully.")
+}

--- a/examples/whatsapp_templates_get.go
+++ b/examples/whatsapp_templates_get.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		fmt.Printf("Error initializing client: %s\n", err)
+		return
+	}
+
+	resp, err := client.WhatsappTemplates.Get("your_waba_id", "your_template_id")
+	if err != nil {
+		fmt.Printf("Error retrieving WhatsApp template: %s\n", err)
+		return
+	}
+	fmt.Printf("Template: %+v\n", resp)
+}

--- a/examples/whatsapp_templates_list.go
+++ b/examples/whatsapp_templates_list.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		fmt.Printf("Error initializing client: %s\n", err)
+		return
+	}
+
+	resp, err := client.WhatsappTemplates.List(
+		"your_waba_id",
+		plivo.WhatsappTemplateListParams{
+			Limit:  20,
+			Offset: 0,
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error listing WhatsApp templates: %s\n", err)
+		return
+	}
+	fmt.Printf("Templates: %+v\n", resp)
+}

--- a/examples/whatsapp_templates_update.go
+++ b/examples/whatsapp_templates_update.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/plivo/plivo-go/v7"
+)
+
+func main() {
+	client, err := plivo.NewClient("YOUR_AUTH_ID", "YOUR_AUTH_TOKEN", &plivo.ClientOptions{})
+	if err != nil {
+		fmt.Printf("Error initializing client: %s\n", err)
+		return
+	}
+
+	resp, err := client.WhatsappTemplates.Update(
+		"your_waba_id",
+		"your_template_id",
+		plivo.WhatsappTemplateUpdateParams{
+			Category: "UTILITY",
+			Components: []plivo.WhatsappTemplateComponent{
+				{
+					Type: "BODY",
+					Parameters: []plivo.Parameter{
+						{
+							Type: "text",
+							Text: "Updated body text",
+						},
+					},
+				},
+			},
+		},
+	)
+	if err != nil {
+		fmt.Printf("Error updating WhatsApp template: %s\n", err)
+		return
+	}
+	fmt.Printf("Template updated: %+v\n", resp)
+}

--- a/fixtures/rcsAssistantEventCreateResponse.json
+++ b/fixtures/rcsAssistantEventCreateResponse.json
@@ -1,0 +1,8 @@
+{
+  "api_id": "some-api-id",
+  "phone_number": "+14151234567",
+  "is_capable": true,
+  "features": ["RICHCARD_STANDALONE", "ACTION_CREATE_CALENDAR_EVENT"],
+  "message": "RCS assistant event sent successfully.",
+  "error": ""
+}

--- a/fixtures/verifySessionCreateResponse.json
+++ b/fixtures/verifySessionCreateResponse.json
@@ -1,0 +1,5 @@
+{
+  "api_id": "api-id-123456",
+  "message": "Session initiated successfully.",
+  "error": ""
+}

--- a/messages.go
+++ b/messages.go
@@ -10,6 +10,13 @@ type MessageService struct {
 	Message
 }
 
+type ContentMessage struct {
+	// Rich elements for RCS messages; only used in RCS messaging.
+	// Using map to allow arbitrary rich content structure.
+	ContentType string      `json:"content_type,omitempty"`
+	Content     interface{} `json:"content,omitempty"`
+}
+
 type MessageCreateParams struct {
 	Src  string `json:"src,omitempty" url:"src,omitempty"`
 	Dst  string `json:"dst,omitempty" url:"dst,omitempty"`
@@ -23,14 +30,15 @@ type MessageCreateParams struct {
 	MediaUrls []string    `json:"media_urls,omitempty" url:"media_urls,omitempty"`
 	MediaIds  []string    `json:"media_ids,omitempty" url:"media_ids,omitempty"`
 	// Either one of src and powerpackuuid should be given
-	PowerpackUUID       string       `json:"powerpack_uuid,omitempty" url:"powerpack_uuid,omitempty"`
-	MessageExpiry       int          `json:"message_expiry,omitempty" url:"message_expiry,omitempty"`
-	Template            *Template    `json:"template,omitempty" url:"template,omitempty"`
-	Interactive         *Interactive `json:"interactive,omitempty" url:"interactive,omitempty"`
-	Location            *Location    `json:"location,omitempty" url:"location,omitempty"`
-	DLTEntityID         string       `json:"dlt_entity_id,omitempty" url:"dlt_entity_id,omitempty"`
-	DLTTemplateID       string       `json:"dlt_template_id,omitempty" url:"dlt_template_id,omitempty"`
-	DLTTemplateCategory string       `json:"dlt_template_category,omitempty" url:"dlt_template_category,omitempty"`
+	PowerpackUUID       string          `json:"powerpack_uuid,omitempty" url:"powerpack_uuid,omitempty"`
+	MessageExpiry       int             `json:"message_expiry,omitempty" url:"message_expiry,omitempty"`
+	Template            *Template       `json:"template,omitempty" url:"template,omitempty"`
+	Interactive         *Interactive    `json:"interactive,omitempty" url:"interactive,omitempty"`
+	Location            *Location       `json:"location,omitempty" url:"location,omitempty"`
+	DLTEntityID         string          `json:"dlt_entity_id,omitempty" url:"dlt_entity_id,omitempty"`
+	DLTTemplateID       string          `json:"dlt_template_id,omitempty" url:"dlt_template_id,omitempty"`
+	DLTTemplateCategory string          `json:"dlt_template_category,omitempty" url:"dlt_template_category,omitempty"`
+	ContentMessage      *ContentMessage `json:"content_message,omitempty" url:"content_message,omitempty"`
 }
 
 type Message struct {

--- a/messages_test.go
+++ b/messages_test.go
@@ -117,3 +117,62 @@ func TestMessageService_Create(t *testing.T) {
 
 	assertRequest(t, "POST", "Message")
 }
+
+func TestMessageService_CreateWithContentMessage(t *testing.T) {
+	expectResponse("messageSendResponse.json", 202)
+	assert := require.New(t)
+	resp, err := client.Messages.Create(MessageCreateParams{
+		Src: "+911231231230",
+		Dst: "+911231231231",
+		ContentMessage: &ContentMessage{
+			ContentType: "rcs_card",
+			Content:     map[string]interface{}{"title": "Hello RCS"},
+		},
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.MessageUUID)
+	assert.Equal(resp.Error, "")
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.Messages.Create(MessageCreateParams{
+		Src: "+911231231230",
+		Dst: "+911231231231",
+		ContentMessage: &ContentMessage{
+			ContentType: "rcs_card",
+			Content:     map[string]interface{}{"title": "Hello RCS"},
+		},
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Message")
+}
+
+func TestMessageGetResponseFields(t *testing.T) {
+	expectResponse("messageGetResponse.json", 200)
+	uuid := "5b40a428-bfc7-4daf-9d06-726c558bf3b8"
+	assert := require.New(t)
+	resp, err := client.Messages.Get(uuid)
+	assert.NotNil(resp)
+	assert.Nil(err)
+	// error_message, message_sent_time, message_updated_time are present on Message struct
+	_ = resp.ErrorMessage
+	_ = resp.MessageSentTime
+	_ = resp.MessageUpdatedTime
+}
+
+func TestMessageListResponseFields(t *testing.T) {
+	expectResponse("messageListResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.Messages.List(MessageListParams{})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.Objects)
+	// error_message, message_sent_time, message_updated_time are present on Message struct
+	_ = resp.Objects[0].ErrorMessage
+	_ = resp.Objects[0].MessageSentTime
+	_ = resp.Objects[0].MessageUpdatedTime
+}

--- a/rcs_assistant_events.go
+++ b/rcs_assistant_events.go
@@ -1,0 +1,28 @@
+package plivo
+
+type RcsAssistantEventService struct {
+	client *Client
+	RcsAssistantEvent
+}
+
+type RcsAssistantEventCreateParams struct {
+}
+
+type RcsAssistantEvent struct {
+	ApiID       string   `json:"api_id,omitempty"`
+	PhoneNumber string   `json:"phone_number,omitempty"`
+	IsCapable   bool     `json:"is_capable,omitempty"`
+	Features    []string `json:"features,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+func (service *RcsAssistantEventService) Create(params RcsAssistantEventCreateParams) (response *RcsAssistantEvent, err error) {
+	req, err := service.client.NewRequest("POST", params, "RCS/AssistantEvents")
+	if err != nil {
+		return
+	}
+	response = &RcsAssistantEvent{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/rcs_assistant_events_test.go
+++ b/rcs_assistant_events_test.go
@@ -1,0 +1,24 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRcsAssistantEventService_Create(t *testing.T) {
+	expectResponse("rcsAssistantEventCreateResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.RcsAssistantEvents.Create(RcsAssistantEventCreateParams{})
+	assert.NotNil(resp)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.RcsAssistantEvents.Create(RcsAssistantEventCreateParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "RCS/AssistantEvents")
+}

--- a/rcs_capability.go
+++ b/rcs_capability.go
@@ -1,0 +1,29 @@
+package plivo
+
+type RcsCapabilityService struct {
+	client *Client
+}
+
+type RcsCapabilityParams struct {
+	PhoneNumber string `json:"phone_number,omitempty" url:"phone_number,omitempty"`
+	AgentUUID   string `json:"agent_uuid,omitempty" url:"agent_uuid,omitempty"`
+}
+
+type RcsCapabilityResponse struct {
+	ApiID       string   `json:"api_id,omitempty"`
+	PhoneNumber string   `json:"phone_number,omitempty"`
+	IsCapable   bool     `json:"is_capable,omitempty"`
+	Features    []string `json:"features,omitempty"`
+	Message     string   `json:"message,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+func (service *RcsCapabilityService) Check(params RcsCapabilityParams) (response *RcsCapabilityResponse, err error) {
+	req, err := service.client.NewRequest("GET", params, "RCS/Capability/")
+	if err != nil {
+		return
+	}
+	response = &RcsCapabilityResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/rcs_capability_test.go
+++ b/rcs_capability_test.go
@@ -1,0 +1,30 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRcsCapabilityService_Check(t *testing.T) {
+	expectResponse("rcsCapabilityCheckResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.RcsCapability.Check(RcsCapabilityParams{
+		PhoneNumber: "+14151234567",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.PhoneNumber)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.RcsCapability.Check(RcsCapabilityParams{
+		PhoneNumber: "+14151234567",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "RCS/Capability/")
+}

--- a/verify_apps.go
+++ b/verify_apps.go
@@ -1,0 +1,201 @@
+package plivo
+
+type VerifyAppService struct {
+	client *Client
+	VerifyApp
+}
+
+type VerifyAppCreateParams struct {
+	Name                  string `json:"name" url:"name"`
+	BrandName             string `json:"brand_name,omitempty" url:"brand_name,omitempty"`
+	OtpType               string `json:"otp_type,omitempty" url:"otp_type,omitempty"`
+	OtpLength             int    `json:"otp_length,omitempty" url:"otp_length,omitempty"`
+	OtpExpiry             int    `json:"otp_expiry,omitempty" url:"otp_expiry,omitempty"`
+	OtpAttempts           int    `json:"otp_attempts,omitempty" url:"otp_attempts,omitempty"`
+	MaxValidationAttempts int    `json:"max_validation_attempts,omitempty" url:"max_validation_attempts,omitempty"`
+	SmsChannel            *bool  `json:"sms_channel,omitempty" url:"sms_channel,omitempty"`
+	VoiceChannel          *bool  `json:"voice_channel,omitempty" url:"voice_channel,omitempty"`
+	WaChannel             *bool  `json:"wa_channel,omitempty" url:"wa_channel,omitempty"`
+	WabaId                string `json:"waba_id,omitempty" url:"waba_id,omitempty"`
+	WabaPhoneNumber       string `json:"waba_phone_number,omitempty" url:"waba_phone_number,omitempty"`
+	WabaTemplateId        string `json:"waba_template_id,omitempty" url:"waba_template_id,omitempty"`
+	TemplateUUID          string `json:"template_uuid,omitempty" url:"template_uuid,omitempty"`
+	IsDefault             *bool  `json:"is_default,omitempty" url:"is_default,omitempty"`
+	MessageRedaction      *bool  `json:"message_redaction,omitempty" url:"message_redaction,omitempty"`
+	EnableFraudshield     *bool  `json:"enable_fraudshield,omitempty" url:"enable_fraudshield,omitempty"`
+	FsProtectionLevel     string `json:"fs_protection_level,omitempty" url:"fs_protection_level,omitempty"`
+	CustomerAppHash       string `json:"customer_app_hash,omitempty" url:"customer_app_hash,omitempty"`
+	NumberPool            string `json:"number_pool,omitempty" url:"number_pool,omitempty"`
+}
+
+type VerifyAppCreateResponseBody struct {
+	ApiID   string `json:"api_id"`
+	AppUUID string `json:"app_uuid"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+type VerifyAppListParams struct {
+	Name           string `url:"name,omitempty"`
+	Subaccount     string `url:"subaccount,omitempty"`
+	Limit          int    `url:"limit,omitempty"`
+	Offset         int    `url:"offset,omitempty"`
+	CreatedAt      string `url:"created_at,omitempty"`
+	CreatedAtLt    string `url:"created_at__lt,omitempty"`
+	CreatedAtLte   string `url:"created_at__lte,omitempty"`
+	CreatedAtGt    string `url:"created_at__gt,omitempty"`
+	CreatedAtGte   string `url:"created_at__gte,omitempty"`
+}
+
+type VerifyAppMeta struct {
+	Previous *string `json:"previous"`
+	Next     *string `json:"next"`
+	Offset   int64   `json:"offset"`
+	Limit    int64   `json:"limit"`
+}
+
+type VerifyApp struct {
+	ApiID             string `json:"api_id,omitempty"`
+	AppUUID           string `json:"app_uuid,omitempty"`
+	Name              string `json:"name,omitempty"`
+	BrandName         string `json:"brand_name,omitempty"`
+	OtpType           string `json:"otp_type,omitempty"`
+	OtpLength         int    `json:"otp_length,omitempty"`
+	OtpExpiry         int    `json:"otp_expiry,omitempty"`
+	OtpAttempts       int    `json:"otp_attempts,omitempty"`
+	MaxValidationAttempts int `json:"max_validation_attempts,omitempty"`
+	SmsChannel        *bool  `json:"sms_channel,omitempty"`
+	VoiceChannel      *bool  `json:"voice_channel,omitempty"`
+	WaChannel         *bool  `json:"wa_channel,omitempty"`
+	WabaId            string `json:"waba_id,omitempty"`
+	WabaPhoneNumber   string `json:"waba_phone_number,omitempty"`
+	WabaTemplateId    string `json:"waba_template_id,omitempty"`
+	TemplateUUID      string `json:"template_uuid,omitempty"`
+	IsDefault         *bool  `json:"is_default,omitempty"`
+	MessageRedaction  *bool  `json:"message_redaction,omitempty"`
+	EnableFraudshield *bool  `json:"enable_fraudshield,omitempty"`
+	FsProtectionLevel string `json:"fs_protection_level,omitempty"`
+	CustomerAppHash   string `json:"customer_app_hash,omitempty"`
+	NumberPool        string `json:"number_pool,omitempty"`
+	CreatedAt         string `json:"created_at,omitempty"`
+	UpdatedAt         string `json:"updated_at,omitempty"`
+}
+
+type VerifyAppWhatsApp struct {
+	WabaId          string `json:"waba_id,omitempty"`
+	WabaPhoneNumber string `json:"waba_phone_number,omitempty"`
+	WabaTemplateId  string `json:"waba_template_id,omitempty"`
+}
+
+type VerifyAppList struct {
+	ApiID      string      `json:"api_id"`
+	VerifyApps []VerifyApp `json:"verify_apps"`
+	Meta       VerifyAppMeta `json:"meta"`
+}
+
+type VerifyAppGetResponseBody struct {
+	ApiID         string             `json:"api_id"`
+	VerifyApp     *VerifyApp         `json:"verify_app"`
+	VerifyWhatsApp *VerifyAppWhatsApp `json:"verify_whatsapp"`
+}
+
+type VerifyAppUpdateParams struct {
+	Name                  string `json:"name,omitempty" url:"name,omitempty"`
+	BrandName             string `json:"brand_name,omitempty" url:"brand_name,omitempty"`
+	OtpType               string `json:"otp_type,omitempty" url:"otp_type,omitempty"`
+	OtpLength             int    `json:"otp_length,omitempty" url:"otp_length,omitempty"`
+	OtpExpiry             int    `json:"otp_expiry,omitempty" url:"otp_expiry,omitempty"`
+	OtpAttempts           int    `json:"otp_attempts,omitempty" url:"otp_attempts,omitempty"`
+	MaxValidationAttempts int    `json:"max_validation_attempts,omitempty" url:"max_validation_attempts,omitempty"`
+	SmsChannel            *bool  `json:"sms_channel,omitempty" url:"sms_channel,omitempty"`
+	VoiceChannel          *bool  `json:"voice_channel,omitempty" url:"voice_channel,omitempty"`
+	WaChannel             *bool  `json:"wa_channel,omitempty" url:"wa_channel,omitempty"`
+	WabaId                string `json:"waba_id,omitempty" url:"waba_id,omitempty"`
+	WabaPhoneNumber       string `json:"waba_phone_number,omitempty" url:"waba_phone_number,omitempty"`
+	WabaTemplateId        string `json:"waba_template_id,omitempty" url:"waba_template_id,omitempty"`
+	TemplateUUID          string `json:"template_uuid,omitempty" url:"template_uuid,omitempty"`
+	IsDefault             *bool  `json:"is_default,omitempty" url:"is_default,omitempty"`
+	MessageRedaction      *bool  `json:"message_redaction,omitempty" url:"message_redaction,omitempty"`
+	EnableFraudshield     *bool  `json:"enable_fraudshield,omitempty" url:"enable_fraudshield,omitempty"`
+	FsProtectionLevel     string `json:"fs_protection_level,omitempty" url:"fs_protection_level,omitempty"`
+	CustomerAppHash       string `json:"customer_app_hash,omitempty" url:"customer_app_hash,omitempty"`
+	Client                string `json:"client,omitempty" url:"client,omitempty"`
+}
+
+type VerifyAppUpdateResponseBody struct {
+	ApiID   string `json:"api_id"`
+	AppUUID string `json:"app_uuid"`
+	Message string `json:"message"`
+	Error   string `json:"error"`
+}
+
+type VerifyAppTemplate struct {
+	TemplateUUID string `json:"template_uuid,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Body         string `json:"body,omitempty"`
+	Language     string `json:"language,omitempty"`
+}
+
+type VerifyAppListTemplatesResponseBody struct {
+	ApiID     string              `json:"api_id"`
+	Templates []VerifyAppTemplate `json:"templates"`
+}
+
+func (service *VerifyAppService) Create(params VerifyAppCreateParams) (response *VerifyAppCreateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Verify/App")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppCreateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) List(params VerifyAppListParams) (response *VerifyAppList, err error) {
+	req, err := service.client.NewRequest("GET", params, "Verify/App")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppList{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) ListTemplates() (response *VerifyAppListTemplatesResponseBody, err error) {
+	req, err := service.client.NewRequest("GET", nil, "Verify/App/templates")
+	if err != nil {
+		return
+	}
+	response = &VerifyAppListTemplatesResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Get(appUUID string) (response *VerifyAppGetResponseBody, err error) {
+	req, err := service.client.NewRequest("GET", nil, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	response = &VerifyAppGetResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Update(appUUID string, params VerifyAppUpdateParams) (response *VerifyAppUpdateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	response = &VerifyAppUpdateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *VerifyAppService) Delete(appUUID string) (err error) {
+	req, err := service.client.NewRequest("DELETE", nil, "Verify/App/%s", appUUID)
+	if err != nil {
+		return
+	}
+	err = service.client.ExecuteRequest(req, nil)
+	return
+}

--- a/verify_apps_test.go
+++ b/verify_apps_test.go
@@ -1,0 +1,126 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyAppService_Create(t *testing.T) {
+	expectResponse("verifyAppCreateResponse.json", 201)
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Create(VerifyAppCreateParams{
+		Name:      "TestApp",
+		BrandName: "TestBrand",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.AppUUID)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Create(VerifyAppCreateParams{
+		Name: "TestApp",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Verify/App")
+}
+
+func TestVerifyAppService_List(t *testing.T) {
+	expectResponse("verifyAppListResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.VerifyApps.List(VerifyAppListParams{})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.VerifyApps)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.List(VerifyAppListParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App")
+}
+
+func TestVerifyAppService_ListTemplates(t *testing.T) {
+	expectResponse("verifyAppListTemplatesResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.VerifyApps.ListTemplates()
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.Templates)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.ListTemplates()
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App/templates")
+}
+
+func TestVerifyAppService_Get(t *testing.T) {
+	expectResponse("verifyAppGetResponse.json", 200)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Get(appUUID)
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotNil(resp.VerifyApp)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Get(appUUID)
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "Verify/App/%s", appUUID)
+}
+
+func TestVerifyAppService_Update(t *testing.T) {
+	expectResponse("verifyAppUpdateResponse.json", 200)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	resp, err := client.VerifyApps.Update(appUUID, VerifyAppUpdateParams{
+		Name: "UpdatedApp",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+	assert.NotEmpty(resp.AppUUID)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifyApps.Update(appUUID, VerifyAppUpdateParams{
+		Name: "UpdatedApp",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Verify/App/%s", appUUID)
+}
+
+func TestVerifyAppService_Delete(t *testing.T) {
+	expectResponse("verifyAppDeleteResponse.json", 204)
+	appUUID := "test-app-uuid-1234"
+	assert := require.New(t)
+	err := client.VerifyApps.Delete(appUUID)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	err = client.VerifyApps.Delete(appUUID)
+	assert.NotNil(err)
+	client.httpClient = cl
+
+	assertRequest(t, "DELETE", "Verify/App/%s", appUUID)
+}

--- a/verify_session.go
+++ b/verify_session.go
@@ -1,0 +1,42 @@
+package plivo
+
+type VerifySessionService struct {
+	client *Client
+	VerifySession
+}
+
+type VerifySessionCreateParams struct {
+	AppHash             string `json:"app_hash,omitempty" url:"app_hash,omitempty"`
+	BrandName           string `json:"brand_name,omitempty" url:"brand_name,omitempty"`
+	CodeLength          int    `json:"code_length,omitempty" url:"code_length,omitempty"`
+	DLTEntityID         string `json:"dlt_entity_id,omitempty" url:"dlt_entity_id,omitempty"`
+	DLTSenderID         string `json:"dlt_sender_id,omitempty" url:"dlt_sender_id,omitempty"`
+	DLTTemplateCategory string `json:"dlt_template_category,omitempty" url:"dlt_template_category,omitempty"`
+	DLTTemplateID       string `json:"dlt_template_id,omitempty" url:"dlt_template_id,omitempty"`
+	DLTText             string `json:"dlt_text,omitempty" url:"dlt_text,omitempty"`
+	DTMF                int    `json:"dtmf,omitempty" url:"dtmf,omitempty"`
+	FraudCheck          string `json:"fraud_check,omitempty" url:"fraud_check,omitempty"`
+	Text                string `json:"text,omitempty" url:"text,omitempty"`
+}
+
+type VerifySession struct {
+	ApiID   string `json:"api_id,omitempty" url:"api_id,omitempty"`
+	Message string `json:"message,omitempty" url:"message,omitempty"`
+	Error   string `json:"error,omitempty" url:"error,omitempty"`
+}
+
+type VerifySessionCreateResponseBody struct {
+	ApiID   string `json:"api_id" url:"api_id"`
+	Message string `json:"message" url:"message"`
+	Error   string `json:"error" url:"error"`
+}
+
+func (service *VerifySessionService) Create(params VerifySessionCreateParams) (response *VerifySessionCreateResponseBody, err error) {
+	req, err := service.client.NewRequest("POST", params, "Verify/Session")
+	if err != nil {
+		return
+	}
+	response = &VerifySessionCreateResponseBody{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}

--- a/verify_session_test.go
+++ b/verify_session_test.go
@@ -1,0 +1,33 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifySessionService_Create(t *testing.T) {
+	expectResponse("verifySessionCreateResponse.json", 200)
+	assert := require.New(t)
+	resp, err := client.VerifySessions.Create(VerifySessionCreateParams{
+		BrandName:  "TestBrand",
+		CodeLength: 6,
+		Text:       "Your OTP is <otp>",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+	assert.NotEmpty(resp.ApiID)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.VerifySessions.Create(VerifySessionCreateParams{
+		BrandName:  "TestBrand",
+		CodeLength: 6,
+		Text:       "Your OTP is <otp>",
+	})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "Verify/Session")
+}

--- a/whatsapp_templates.go
+++ b/whatsapp_templates.go
@@ -1,0 +1,130 @@
+package plivo
+
+type WhatsappTemplateService struct {
+	client *Client
+}
+
+type WhatsappTemplateComponent struct {
+	Type       string      `json:"type,omitempty"`
+	SubType    string      `json:"sub_type,omitempty"`
+	Index      string      `json:"index,omitempty"`
+	Parameters []Parameter `json:"parameters,omitempty"`
+	Cards      []Card      `json:"cards,omitempty"`
+}
+
+type WhatsappTemplateCreateParams struct {
+	Name                string                      `json:"name,omitempty"`
+	Category            string                      `json:"category,omitempty"`
+	Language            string                      `json:"language,omitempty"`
+	Components          []WhatsappTemplateComponent `json:"components,omitempty"`
+	AllowCategoryChange bool                        `json:"allow_category_change,omitempty"`
+}
+
+type WhatsappTemplateUpdateParams struct {
+	Name                string                      `json:"name,omitempty"`
+	Category            string                      `json:"category,omitempty"`
+	Language            string                      `json:"language,omitempty"`
+	Components          []WhatsappTemplateComponent `json:"components,omitempty"`
+	AllowCategoryChange bool                        `json:"allow_category_change,omitempty"`
+}
+
+type WhatsappTemplateListParams struct {
+	TemplateName string `url:"template_name,omitempty"`
+	Limit        int    `url:"limit,omitempty"`
+	Offset       int    `url:"offset,omitempty"`
+}
+
+type WhatsappTemplateDeleteParams struct {
+	Name string `url:"name"`
+}
+
+type WhatsappTemplateResponse struct {
+	ApiID            string      `json:"api_id,omitempty"`
+	TemplateID       string      `json:"template_id,omitempty"`
+	TemplateName     string      `json:"template_name,omitempty"`
+	TemplateStatus   string      `json:"template_status,omitempty"`
+	TemplateCategory string      `json:"template_category,omitempty"`
+	TemplateLanguage string      `json:"template_language,omitempty"`
+	Status           string      `json:"status,omitempty"`
+	Message          string      `json:"message,omitempty"`
+	Error            interface{} `json:"error,omitempty"`
+}
+
+type WhatsappTemplateGetResponse struct {
+	ApiID          string                      `json:"api_id,omitempty"`
+	TemplateID     string                      `json:"template_id,omitempty"`
+	Name           string                      `json:"name,omitempty"`
+	Category       string                      `json:"category,omitempty"`
+	Language       string                      `json:"language,omitempty"`
+	Status         string                      `json:"status,omitempty"`
+	Components     []WhatsappTemplateComponent `json:"components,omitempty"`
+	QualityScore   interface{}                 `json:"quality_score,omitempty"`
+	RejectedReason string                      `json:"rejected_reason,omitempty"`
+	Message        string                      `json:"message,omitempty"`
+	Error          interface{}                 `json:"error,omitempty"`
+}
+
+type WhatsappTemplateListMeta struct {
+	Previous *string `json:"previous,omitempty"`
+	Next     *string `json:"next,omitempty"`
+	Offset   int64   `json:"offset,omitempty"`
+	Limit    int64   `json:"limit,omitempty"`
+}
+
+type WhatsappTemplateListResponse struct {
+	ApiID   string                      `json:"api_id,omitempty"`
+	Objects []WhatsappTemplateGetResponse `json:"objects,omitempty"`
+	Meta    WhatsappTemplateListMeta    `json:"meta,omitempty"`
+	Status  string                      `json:"status,omitempty"`
+	Message string                      `json:"message,omitempty"`
+	Error   interface{}                 `json:"error,omitempty"`
+}
+
+func (service *WhatsappTemplateService) Create(wabaID string, params WhatsappTemplateCreateParams) (response *WhatsappTemplateResponse, err error) {
+	req, err := service.client.NewRequest("POST", params, "WhatsApp/Template/%s/", wabaID)
+	if err != nil {
+		return
+	}
+	response = &WhatsappTemplateResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsappTemplateService) Update(wabaID string, templateID string, params WhatsappTemplateUpdateParams) (response *WhatsappTemplateResponse, err error) {
+	req, err := service.client.NewRequest("POST", params, "WhatsApp/Template/%s/%s/", wabaID, templateID)
+	if err != nil {
+		return
+	}
+	response = &WhatsappTemplateResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsappTemplateService) Get(wabaID string, templateID string) (response *WhatsappTemplateGetResponse, err error) {
+	req, err := service.client.NewRequest("GET", nil, "WhatsApp/Template/%s/%s/", wabaID, templateID)
+	if err != nil {
+		return
+	}
+	response = &WhatsappTemplateGetResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsappTemplateService) List(wabaID string, params WhatsappTemplateListParams) (response *WhatsappTemplateListResponse, err error) {
+	req, err := service.client.NewRequest("GET", params, "WhatsApp/Template/%s/", wabaID)
+	if err != nil {
+		return
+	}
+	response = &WhatsappTemplateListResponse{}
+	err = service.client.ExecuteRequest(req, response)
+	return
+}
+
+func (service *WhatsappTemplateService) Delete(wabaID string, templateID string, params WhatsappTemplateDeleteParams) (err error) {
+	req, err := service.client.NewRequest("DELETE", params, "WhatsApp/Template/%s/%s/", wabaID, templateID)
+	if err != nil {
+		return
+	}
+	err = service.client.ExecuteRequest(req, nil)
+	return
+}

--- a/whatsapp_templates_test.go
+++ b/whatsapp_templates_test.go
@@ -1,0 +1,106 @@
+package plivo
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestWhatsappTemplateService_Create(t *testing.T) {
+	expectResponse("whatsappTemplateCreateResponse.json", 200)
+	assert := require.New(t)
+	wabaID := "test-waba-id"
+	resp, err := client.WhatsappTemplates.Create(wabaID, WhatsappTemplateCreateParams{
+		Name:     "test_template",
+		Category: "MARKETING",
+		Language: "en_US",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.WhatsappTemplates.Create(wabaID, WhatsappTemplateCreateParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "WhatsApp/Template/%s/", wabaID)
+}
+
+func TestWhatsappTemplateService_Update(t *testing.T) {
+	expectResponse("whatsappTemplateUpdateResponse.json", 200)
+	assert := require.New(t)
+	wabaID := "test-waba-id"
+	templateID := "test-template-id"
+	resp, err := client.WhatsappTemplates.Update(wabaID, templateID, WhatsappTemplateUpdateParams{
+		Category: "UTILITY",
+	})
+	assert.NotNil(resp)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.WhatsappTemplates.Update(wabaID, templateID, WhatsappTemplateUpdateParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "POST", "WhatsApp/Template/%s/%s/", wabaID, templateID)
+}
+
+func TestWhatsappTemplateService_Get(t *testing.T) {
+	expectResponse("whatsappTemplateGetResponse.json", 200)
+	assert := require.New(t)
+	wabaID := "test-waba-id"
+	templateID := "test-template-id"
+	resp, err := client.WhatsappTemplates.Get(wabaID, templateID)
+	assert.NotNil(resp)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.WhatsappTemplates.Get(wabaID, templateID)
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "WhatsApp/Template/%s/%s/", wabaID, templateID)
+}
+
+func TestWhatsappTemplateService_List(t *testing.T) {
+	expectResponse("whatsappTemplateListResponse.json", 200)
+	assert := require.New(t)
+	wabaID := "test-waba-id"
+	resp, err := client.WhatsappTemplates.List(wabaID, WhatsappTemplateListParams{})
+	assert.NotNil(resp)
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	resp, err = client.WhatsappTemplates.List(wabaID, WhatsappTemplateListParams{})
+	assert.NotNil(err)
+	assert.Nil(resp)
+	client.httpClient = cl
+
+	assertRequest(t, "GET", "WhatsApp/Template/%s/", wabaID)
+}
+
+func TestWhatsappTemplateService_Delete(t *testing.T) {
+	expectResponse("whatsappTemplateDeleteResponse.json", 204)
+	assert := require.New(t)
+	wabaID := "test-waba-id"
+	templateID := "test-template-id"
+	err := client.WhatsappTemplates.Delete(wabaID, templateID, WhatsappTemplateDeleteParams{
+		Name: "test_template",
+	})
+	assert.Nil(err)
+
+	cl := client.httpClient
+	client.httpClient = nil
+	err = client.WhatsappTemplates.Delete(wabaID, templateID, WhatsappTemplateDeleteParams{Name: "test_template"})
+	assert.NotNil(err)
+	client.httpClient = cl
+
+	assertRequest(t, "DELETE", "WhatsApp/Template/%s/%s/", wabaID, templateID)
+}


### PR DESCRIPTION
# Add whatsapp_templates.create, whatsapp_templates.update, whatsapp_templates.get, whatsapp_templates.list, whatsapp_templates.delete, verify_apps.create, verify_apps.list, verify_apps.list_templates, verify_apps.get, verify_apps.update, verify_apps.delete, rcs_capability.check, rcs_assistant_events.create, verify_session.create, messages.create, messages.list, messages.get, verify_apps.create

Base: master ← rune/pr-630-sdk-updates

Reviewers (picked by recent commit activity):
- @avinashp-plivo (3 commits)
- @narayana-plivo (3 commits)

Adds the following methods:

- `whatsapp_templates.create()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — Create a WhatsApp message template under the given WABA.
- `whatsapp_templates.update()` — `POST /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Update an existing WhatsApp message template.
- `whatsapp_templates.get()` — `GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Retrieve a WhatsApp template by its ID.
- `whatsapp_templates.list()` — `GET /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/` — List WhatsApp templates for the given WABA with optional name filter and pagination.
- `whatsapp_templates.delete()` — `DELETE /v1/Account/{auth_id}/WhatsApp/Template/{waba_id}/{template_id}/` — Delete a WhatsApp template by ID and name.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Create a Verify application for the account.
- `verify_apps.list()` — `GET /v1/Account/{auth_id}/Verify/App/` — List Verify applications for an account with optional filters.
- `verify_apps.list_templates()` — `GET /v1/Account/{auth_id}/Verify/App/templates/` — List default Verify templates available to the account.
- `verify_apps.get()` — `GET /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Retrieve a Verify application by its UUID.
- `verify_apps.update()` — `POST /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Update a Verify application (partial update — request body must include at least one field).
- `verify_apps.delete()` — `DELETE /v1/Account/{auth_id}/Verify/App/{app_uuid}/` — Delete a Verify application.
- `rcs_capability.check()` — `GET /v1/Account/{auth_id}/RCS/Capability/` — Check if a phone number is RCS-enabled.
- `rcs_assistant_events.create()` — `POST /v1/Account/{auth_id}/RCS/AssistantEvents/` — Send RCS assistant events.
- `verify_session.create()` — `POST /v1/Account/{auth_id}/Verify/Session/` — Handle user session for generating OTP based on the request.
- `messages.create()` — `POST /v1/Account/{auth_id}/Message/` — Add content_message field for RCS rich content to the send message request.
- `messages.list()` — `GET /v1/Account/{auth_id}/Message/` — Add error_message, message_sent_time, and message_updated_time fields to the list messages response.
- `messages.get()` — `GET /v1/Account/{auth_id}/Message/{record_id}/` — Add error_message, message_sent_time, and message_updated_time fields to the get message response.
- `verify_apps.create()` — `POST /v1/Account/{auth_id}/Verify/App/` — Add number_pool field to the Verify app create request.

Each method ships with a unit test, a usage example, a bumped version, and a CHANGELOG entry.
