### PR TITLE
feat: add number_of_employees field to Profile API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Change Log
+## [7.60.2](https://github.com/plivo/plivo-go/tree/v7.60.2) (2026-06-10)
+**Feature - Profile API number of employees field support**
+- Added Number of Employees field support to Profile API
+
 ## [7.60.1](https://github.com/plivo/plivo-go/tree/v7.60.1) (2026-05-26)
 **Feature - Profile API DBA field support**
 - Added Doing Business As (DBA) field support to Profile API

--- a/baseclient.go
+++ b/baseclient.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/go-querystring/query"
 )
 
-const sdkVersion = "7.60.1"
+const sdkVersion = "7.60.2"
 
 const lookupBaseUrl = "lookup.plivo.com"
 

--- a/fixtures/profileGetResponse.json
+++ b/fixtures/profileGetResponse.json
@@ -20,6 +20,7 @@
         "company_name": "ABC Inc",
         "customer_type": "DIRECT",
         "doing_business_as": "ABC DBA",
+        "number_of_employees": "BETWEEN_1_AND_10",
         "ein": "111111111",
         "ein_issuing_country": "US",
         "entity_type": "GOVERNMENT",

--- a/profile.go
+++ b/profile.go
@@ -5,23 +5,27 @@ type ProfileService struct {
 }
 
 type CreateProfileRequestParams struct {
-	ProfileAlias      string             `json:"profile_alias" validate:"required"`
-	CustomerType      string             `json:"customer_type" validate:"oneof= DIRECT RESELLER"`
-	EntityType        string             `json:"entity_type" validate:"oneof= PRIVATE PUBLIC NON_PROFIT GOVERNMENT INDIVIDUAL"`
-	CompanyName       string             `json:"company_name" validate:"required,max=100"`
-	Ein               string             `json:"ein" validate:"max=100"`
-	EinIssuingCountry string             `json:"ein_issuing_country" validate:"max=2"`
-	Address           *Address           `json:"address" validate:"required"`
-	StockSymbol       string             `json:"stock_symbol" validate:"required_if=EntityType PUBLIC,max=10"`
-	StockExchange     string             `json:"stock_exchange" validate:"required_if=EntityType PUBLIC,oneof= NASDAQ NYSE AMEX AMX ASX B3 BME BSE FRA ICEX JPX JSE KRX LON NSE OMX SEHK SGX SSE STO SWX SZSE TSX TWSE VSE OTHER ''"`
-	Website           string             `json:"website" validate:"max=100"`
-	Vertical          string             `json:"vertical" validate:"oneof= PROFESSIONAL REAL_ESTATE HEALTHCARE HUMAN_RESOURCES ENERGY ENTERTAINMENT RETAIL TRANSPORTATION AGRICULTURE INSURANCE POSTAL EDUCATION HOSPITALITY FINANCIAL POLITICAL GAMBLING LEGAL CONSTRUCTION NGO MANUFACTURING GOVERNMENT TECHNOLOGY COMMUNICATION"`
-	AltBusinessID     string             `json:"alt_business_id" validate:"max=50"`
-	AltBusinessidType string             `json:"alt_business_id_type" validate:"oneof= DUNS LEI GIIN NONE ''"`
-	PlivoSubaccount   string             `json:"plivo_subaccount" validate:"max=20"`
-	AuthorizedContact *AuthorizedContact `json:"authorized_contact"`
-	BusinessContactEmail string         `json:"business_contact_email,omitempty" validate:"omitempty,email,max=255"`
-	DoingBusinessAs      string         `json:"doing_business_as,omitempty" validate:"max=100"`
+	ProfileAlias         string             `json:"profile_alias" validate:"required"`
+	CustomerType         string             `json:"customer_type" validate:"oneof= DIRECT RESELLER"`
+	EntityType           string             `json:"entity_type" validate:"oneof= PRIVATE PUBLIC NON_PROFIT GOVERNMENT INDIVIDUAL"`
+	CompanyName          string             `json:"company_name" validate:"required,max=100"`
+	Ein                  string             `json:"ein" validate:"max=100"`
+	EinIssuingCountry    string             `json:"ein_issuing_country" validate:"max=2"`
+	Address              *Address           `json:"address" validate:"required"`
+	StockSymbol          string             `json:"stock_symbol" validate:"required_if=EntityType PUBLIC,max=10"`
+	StockExchange        string             `json:"stock_exchange" validate:"required_if=EntityType PUBLIC,oneof= NASDAQ NYSE AMEX AMX ASX B3 BME BSE FRA ICEX JPX JSE KRX LON NSE OMX SEHK SGX SSE STO SWX SZSE TSX TWSE VSE OTHER ''"`
+	Website              string             `json:"website" validate:"max=100"`
+	Vertical             string             `json:"vertical" validate:"oneof= PROFESSIONAL REAL_ESTATE HEALTHCARE HUMAN_RESOURCES ENERGY ENTERTAINMENT RETAIL TRANSPORTATION AGRICULTURE INSURANCE POSTAL EDUCATION HOSPITALITY FINANCIAL POLITICAL GAMBLING LEGAL CONSTRUCTION NGO MANUFACTURING GOVERNMENT TECHNOLOGY COMMUNICATION"`
+	AltBusinessID        string             `json:"alt_business_id" validate:"max=50"`
+	AltBusinessidType    string             `json:"alt_business_id_type" validate:"oneof= DUNS LEI GIIN NONE ''"`
+	PlivoSubaccount      string             `json:"plivo_subaccount" validate:"max=20"`
+	AuthorizedContact    *AuthorizedContact `json:"authorized_contact"`
+	BusinessContactEmail string             `json:"business_contact_email,omitempty" validate:"omitempty,email,max=255"`
+	DoingBusinessAs      string             `json:"doing_business_as,omitempty" validate:"max=100"`
+	// NumberOfEmployees is optional and validated server-side (no client-side enum validation).
+	// Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500,
+	// BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
+	NumberOfEmployees string `json:"number_of_employees,omitempty"`
 }
 
 type CreateProfileResponse struct {
@@ -69,30 +73,35 @@ type UpdateProfileRequestParams struct {
 	AltBusinessID        string             `json:"alt_business_id,omitempty" validate:"max=50"`
 	AltBusinessidType    string             `json:"alt_business_id_type,omitempty" validate:"oneof= DUNS LEI GIIN NONE ''"`
 	DoingBusinessAs      string             `json:"doing_business_as,omitempty" validate:"max=100"`
+	// NumberOfEmployees is optional and validated server-side (no client-side enum validation).
+	// Allowed values: BETWEEN_1_AND_10, BETWEEN_11_AND_50, BETWEEN_51_AND_200, BETWEEN_201_AND_500,
+	// BETWEEN_501_AND_2000, BETWEEN_2001_AND_10000, MORE_THAN_10001
+	NumberOfEmployees string `json:"number_of_employees,omitempty"`
 }
 
 type Profile struct {
-	ProfileUUID       string            `json:"profile_uuid,omitempty"`
-	ProfileAlias      string            `json:"profile_alias,omitempty"`
-	ProfileType       string            `json:"profile_type,omitempty"`
-	PrimaryProfile    string            `json:"primary_profile,omitempty"`
-	CustomerType      string            `json:"customer_type,omitempty"`
-	EntityType        string            `json:"entity_type,omitempty"`
-	CompanyName       string            `json:"company_name,omitempty"`
-	Ein               string            `json:"ein,omitempty"`
-	EinIssuingCountry string            `json:"ein_issuing_country,omitempty"`
-	Address           Address           `json:"address,omitempty"`
-	StockSymbol       string            `json:"stock_symbol,omitempty"`
-	StockExchange     string            `json:"stock_exchange,omitempty"`
-	Website           string            `json:"website,omitempty"`
-	Vertical          string            `json:"vertical,omitempty"`
-	AltBusinessID     string            `json:"alt_business_id,omitempty"`
-	AltBusinessidType string            `json:"alt_business_id_type,omitempty"`
-	PlivoSubaccount   string            `json:"plivo_subaccount,omitempty"`
-	AuthorizedContact AuthorizedContact `json:"authorized_contact,omitempty"`
-	BusinessContactEmail string         `json:"business_contact_email,omitempty"`
-	DoingBusinessAs   string            `json:"doing_business_as,omitempty"`
-	CreatedAt         string            `json:"created_at,omitempty"`
+	ProfileUUID          string            `json:"profile_uuid,omitempty"`
+	ProfileAlias         string            `json:"profile_alias,omitempty"`
+	ProfileType          string            `json:"profile_type,omitempty"`
+	PrimaryProfile       string            `json:"primary_profile,omitempty"`
+	CustomerType         string            `json:"customer_type,omitempty"`
+	EntityType           string            `json:"entity_type,omitempty"`
+	CompanyName          string            `json:"company_name,omitempty"`
+	Ein                  string            `json:"ein,omitempty"`
+	EinIssuingCountry    string            `json:"ein_issuing_country,omitempty"`
+	Address              Address           `json:"address,omitempty"`
+	StockSymbol          string            `json:"stock_symbol,omitempty"`
+	StockExchange        string            `json:"stock_exchange,omitempty"`
+	Website              string            `json:"website,omitempty"`
+	Vertical             string            `json:"vertical,omitempty"`
+	AltBusinessID        string            `json:"alt_business_id,omitempty"`
+	AltBusinessidType    string            `json:"alt_business_id_type,omitempty"`
+	PlivoSubaccount      string            `json:"plivo_subaccount,omitempty"`
+	AuthorizedContact    AuthorizedContact `json:"authorized_contact,omitempty"`
+	BusinessContactEmail string            `json:"business_contact_email,omitempty"`
+	DoingBusinessAs      string            `json:"doing_business_as,omitempty"`
+	NumberOfEmployees    string            `json:"number_of_employees,omitempty"`
+	CreatedAt            string            `json:"created_at,omitempty"`
 }
 
 func (service *ProfileService) List(param ProfileListParams) (response *ProfileListResponse, err error) {

--- a/profile_test.go
+++ b/profile_test.go
@@ -33,6 +33,7 @@ func TestProfile_Get(t *testing.T) {
 	assert.Nil(err)
 	assert.Equal(ProfileUUID, profile.Profile.ProfileUUID)
 	assert.Equal("ABC DBA", profile.Profile.DoingBusinessAs)
+	assert.Equal("BETWEEN_1_AND_10", profile.Profile.NumberOfEmployees)
 	assert.NotEmpty(profile.ApiID)
 
 	cl := client.httpClient
@@ -77,6 +78,7 @@ func TestProfile_Create(t *testing.T) {
 		},
 		BusinessContactEmail: "employee@company.com",
 		DoingBusinessAs:      "Test DBA",
+		NumberOfEmployees:    "BETWEEN_1_AND_10",
 	})
 	assert.NotNil(resp)
 	assert.Nil(err)
@@ -113,6 +115,7 @@ func TestProfile_Create(t *testing.T) {
 		},
 		BusinessContactEmail: "employee@company.com",
 		DoingBusinessAs:      "Test DBA",
+		NumberOfEmployees:    "BETWEEN_1_AND_10",
 	})
 	assert.NotNil(err)
 	assert.Nil(resp)
@@ -169,6 +172,7 @@ func TestProfile_Update(t *testing.T) {
 		AltBusinessID:        "123456789",
 		AltBusinessidType:    "DUNS",
 		DoingBusinessAs:      "Updated DBA",
+		NumberOfEmployees:    "BETWEEN_11_AND_50",
 	})
 	assert.NotNil(resp)
 	assert.Nil(err)
@@ -201,6 +205,7 @@ func TestProfile_Update(t *testing.T) {
 		AltBusinessID:        "123456789",
 		AltBusinessidType:    "DUNS",
 		DoingBusinessAs:      "Updated DBA",
+		NumberOfEmployees:    "BETWEEN_11_AND_50",
 	})
 	assert.NotNil(err)
 	assert.Nil(resp)


### PR DESCRIPTION
## Summary
Adds a new optional `number_of_employees` field to the Profile (10DLC/A2P) API in the plivo-go SDK, mirroring the campaign-service backend change where it was added to the Profile create & update request as an optional string.

Follows the exact same pattern as the recently added `doing_business_as` (DBA) field.

## Changes
- `profile.go`: Added `NumberOfEmployees string` (json `number_of_employees,omitempty`) right after `DoingBusinessAs` in `CreateProfileRequestParams`, `UpdateProfileRequestParams`, and the `Profile` response struct.
- No client-side enum validation (server validates) — matches `DoingBusinessAs` / `BusinessContactEmail`. The 7 allowed values are documented in a code comment.
- `profile_test.go`: Set `NumberOfEmployees` in Create/Update test params and added a Get assertion, mirroring DBA.
- `fixtures/profileGetResponse.json`: Added `number_of_employees` to the fixture.
- `CHANGELOG.md`: New entry at top (2026-06-10).
- `baseclient.go`: Bumped `sdkVersion` 7.60.1 -> 7.60.2.

## Allowed values (server-validated, documented only)
`BETWEEN_1_AND_10`, `BETWEEN_11_AND_50`, `BETWEEN_51_AND_200`, `BETWEEN_201_AND_500`, `BETWEEN_501_AND_2000`, `BETWEEN_2001_AND_10000`, `MORE_THAN_10001`

## Verification
- `go build ./...` passes
- `go test -run TestProfile ./...` passes
- `gofmt -l` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)